### PR TITLE
feat(spreadsheet): add new route to import a product spreadsheet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 
+# Import/export spreadsheets
+gem "roo", "~> 2.10.0"
+
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,9 @@ GEM
       psych (>= 4.0.0)
     reline (0.5.7)
       io-console (~> 0.5)
+    roo (2.10.1)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
@@ -199,6 +202,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
+    rubyzip (2.3.2)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)
@@ -229,6 +233,7 @@ DEPENDENCIES
   pry (~> 0.14.2)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.3)
+  roo (~> 2.10.0)
   rspec-rails (~> 6.1.0)
   shoulda-matchers
   simplecov

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -38,6 +38,11 @@ class ProductsController < ApplicationController
     @product.destroy!
   end
 
+  # POST /products/import
+  def import
+    Products::Import.new(spreadsheet: params[:file]).call
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def find_product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,4 @@
 class Product < ApplicationRecord
-  validates :lm, :name, :free_shipping, :price, presence: true
+  validates :lm, :name, :price, presence: true
+  validates :lm, numericality: { only_integer: true }
 end

--- a/app/services/products/import.rb
+++ b/app/services/products/import.rb
@@ -1,0 +1,28 @@
+module Products
+  class Import
+    def initialize(spreadsheet:)
+      @spreadsheet = Roo::Spreadsheet.open(spreadsheet)
+      @errors = []
+    end
+
+    def call
+      @spreadsheet.each_with_pagename do |name, sheet|
+        @sheet_errors = []
+        next if sheet.first_column.nil?
+
+        sheet.each(lm: 'lm', name: 'name', free_shipping: 'free_shipping', description: 'description', price: 'price') do |hash|
+          product = Product.new(hash)
+
+          if product.valid?
+            product.save
+          else
+            @sheet_errors << "Product lm: #{product.lm} -> errors: #{product.errors.messages}"
+          end
+        end
+
+        @errors << @sheet_errors
+      end
+      puts @errors
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  resources :products
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -8,4 +7,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "products#index"
+
+  post 'products/import', to: 'products#import'
+  resources :products
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - .:/app
     depends_on:
       - db
-    command: rails s -b 0.0.0.0
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -b 3000 -b 0.0.0.0"
     stdin_open: true
     tty: true
     environment:

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Product, type: :model do
     context 'with valid attributes' do
       let(:attributes) do
         {
-          "lm": "1002",
+          "lm": 1002,
           "name": "First Product",
           "free_shipping": 1,
           "description": "The better Product",
@@ -38,14 +38,14 @@ RSpec.describe Product, type: :model do
 
       it 'returns an error message' do
         subject
-        expect(product.errors.messages).to match({:lm=>["can't be blank"]})
+        expect(product.errors.messages).to match({:lm=>["can't be blank", "is not a number"]})
       end
     end
 
     context 'without name' do
       let(:attributes) do
         {
-          "lm": "1002",
+          "lm": 1002,
           "free_shipping": 1,
           "description": "The better Product",
           "price": 200
@@ -60,28 +60,10 @@ RSpec.describe Product, type: :model do
       end
     end
 
-    context 'without free_shipping' do
-      let(:attributes) do
-        {
-          "lm": "1002",
-          "name": "First Product",
-          "description": "The better Product",
-          "price": 200
-        }
-      end
-
-      it { expect(subject).to be_falsey }
-
-      it 'returns an error message' do
-        subject
-        expect(product.errors.messages).to match({:free_shipping=>["can't be blank"]})
-      end
-    end
-
     context 'without price' do
       let(:attributes) do
         {
-          "lm": "1002",
+          "lm": 1002,
           "name": "First Product",
           "free_shipping": 1,
           "description": "The better Product",
@@ -105,7 +87,7 @@ RSpec.describe Product, type: :model do
 
       it 'returns an error message' do
         subject
-        expect(product.errors.messages).to match({:free_shipping=>["can't be blank"], :lm=>["can't be blank"], :name=>["can't be blank"], :price=>["can't be blank"]})
+        expect(product.errors.messages).to match({:lm=>["can't be blank", "is not a number"], :name=>["can't be blank"], :price=>["can't be blank"]})
       end
     end
   end


### PR DESCRIPTION
# feat(spreadsheet): add new route to import a product spreadsheet

## Description
Install the gem [roo](https://github.com/roo-rb/roo) to import spreadsheet and a new route to import a products spreadsheet with the following format

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
lm | name | free_shipping | description | price
-- | -- | -- | -- | --
1001 | Nail X | 0 | Very strong nail X | 100.00
1002 | Hammer Y | 1 | Good material Y | 140.00
1003 | Glue X | 0 | sticky glue | 20.00
1008 | Eletric Saw | 1 | Power 1400W model 4100NH2Z-127V-L | 399.00
1010 | Gloves | 0 | Very basic | 5.60

## Comments
Fix docker compose to remove the temporary file server.pid when start the server

## Tests
### Config
Download this branch and run: 
`docker-compose build`

Up your containers
docker-compose up

### Execute

IMPORT
Request
Using an API client sends a POST request to http://localhost:3000/products/import 
select the body option: "Multipart" and create an attribute "file", select the file option and choose your spreadsheet with the same format as the example

Response
Status: 204
Body: null



